### PR TITLE
Fix font-awesome missing in the compendium

### DIFF
--- a/public/vtt-tmp/assets/compendium/compendium.html
+++ b/public/vtt-tmp/assets/compendium/compendium.html
@@ -5,7 +5,9 @@
     <link rel="stylesheet" href="compendium.css">
     <link rel="stylesheet" href="../colmeia.css">
     <link rel="stylesheet" href="../cards.css">
-    <link rel="stylesheet" href="../font/css/all.min.css">
+    <!-- TODO: move the CDN imports to be on package.json instead when migrating this to React -->
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.3/css/solid.css" integrity="sha384-LA8Ug4T/nhVkyhrSmSirsoAo9iDrBk8E7U80aSPeD+w3vO8PzOJIS6agGcbIwwX0" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.3/css/fontawesome.css" integrity="sha384-wESLQ85D6gbsF459vf1CiZ2+rr+CsxRY0RpiF1tLlQpDnAgg6rwdsUF1+Ics2bni" crossorigin="anonymous">
     <title>Compêndio</title>
 </head>
 <body>


### PR DESCRIPTION
Font-awesome import was missing in the compendium, for now working with CDN imports.